### PR TITLE
Update for key sharing 2025

### DIFF
--- a/KeyShareConsumer.xcodeproj/project.pbxproj
+++ b/KeyShareConsumer.xcodeproj/project.pbxproj
@@ -256,7 +256,7 @@
 				TargetAttributes = {
 					55FE830C1B6BB72B0072DCCD = {
 						CreatedOnToolsVersion = 6.1.1;
-						DevelopmentTeam = 2FBELHR72N;
+						DevelopmentTeam = M355KP63QV;
 						SystemCapabilities = {
 							com.apple.iCloud = {
 								enabled = 1;
@@ -265,7 +265,7 @@
 					};
 					55FE83251B6BB72B0072DCCD = {
 						CreatedOnToolsVersion = 6.1.1;
-						DevelopmentTeam = 2FBELHR72N;
+						DevelopmentTeam = M355KP63QV;
 						TestTargetID = 55FE830C1B6BB72B0072DCCD;
 					};
 				};
@@ -275,6 +275,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -456,11 +457,11 @@
 				CODE_SIGN_ENTITLEMENTS = KeyShareConsumer/KeyShareConsumer.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = 2FBELHR72N;
+				DEVELOPMENT_TEAM = M355KP63QV;
 				INFOPLIST_FILE = KeyShareConsumer/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = red.hound.enterprise.KeyShareConsumer;
+				PRODUCT_BUNDLE_IDENTIFIER = rhs.KeyShareConsumer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				VALID_ARCHS = "arm64 armv7";
@@ -474,11 +475,11 @@
 				CODE_SIGN_ENTITLEMENTS = KeyShareConsumer/KeyShareConsumer.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = 2FBELHR72N;
+				DEVELOPMENT_TEAM = M355KP63QV;
 				INFOPLIST_FILE = KeyShareConsumer/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = red.hound.enterprise.KeyShareConsumer;
+				PRODUCT_BUNDLE_IDENTIFIER = rhs.KeyShareConsumer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				VALID_ARCHS = "arm64 armv7";
@@ -489,7 +490,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				DEVELOPMENT_TEAM = 2FBELHR72N;
+				DEVELOPMENT_TEAM = M355KP63QV;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -512,7 +513,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				DEVELOPMENT_TEAM = 2FBELHR72N;
+				DEVELOPMENT_TEAM = M355KP63QV;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",

--- a/KeyShareConsumer/KeyChainDataSource.mm
+++ b/KeyShareConsumer/KeyChainDataSource.mm
@@ -52,8 +52,8 @@ CFTypeRef g_identityAttrs[] = {
     kSecAttrCertificateType,
     kSecAttrCertificateEncoding,
     kSecAttrLabel,
-    kSecAttrSubject,
-    kSecAttrIssuer,
+//    kSecAttrSubject,
+//    kSecAttrIssuer,
     kSecAttrSerialNumber,
     kSecAttrSubjectKeyID,
     kSecAttrPublicKeyHash,
@@ -824,7 +824,7 @@ CFTypeRef g_miscRelatedAttrs[] = {
                 attrs = g_keyAttrs;
                 break;
             default:
-                return 0;
+                return @"Unrecognized mode";
         }
         
         for(int ii = 0, jj = 0; attrs[ii]; ++ii)

--- a/KeyShareConsumer/Settings.bundle/Root.plist
+++ b/KeyShareConsumer/Settings.bundle/Root.plist
@@ -16,7 +16,7 @@
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
-			<string>All keys (com.rsa.pkcs-12)</string>
+			<string>All keys (purebred2025.rsa.pkcs-12)</string>
 			<key>Key</key>
 			<string>toggle_com_rsa_pkcs12</string>
 			<key>DefaultValue</key>
@@ -26,7 +26,7 @@
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
-			<string>All keys (purebred.select.all)</string>
+			<string>All keys (purebred2025.select.all)</string>
 			<key>Key</key>
 			<string>toggle_purebred_select_all</string>
 			<key>DefaultValue</key>
@@ -36,7 +36,7 @@
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
-			<string>All user keys (purebred.select.all.user)</string>
+			<string>All user keys (purebred2025.select.all.user)</string>
 			<key>Key</key>
 			<string>toggle_purebred_select_all_user</string>
 			<key>DefaultValue</key>
@@ -46,7 +46,7 @@
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
-			<string>All user keys (purebred.select.all-user)</string>
+			<string>All user keys (purebred2025.select.all-user)</string>
 			<key>Key</key>
 			<string>toggle_purebred_select_all-user</string>
 			<key>DefaultValue</key>
@@ -56,7 +56,7 @@
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
-			<string>Signature keys (purebred.select.signature)</string>
+			<string>Signature keys (purebred2025.select.signature)</string>
 			<key>Key</key>
 			<string>toggle_purebred_select_signature</string>
 			<key>DefaultValue</key>
@@ -66,7 +66,7 @@
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
-			<string>All encryption keys (purebred.select.encryption)</string>
+			<string>All encryption keys (purebred2025.select.encryption)</string>
 			<key>Key</key>
 			<string>toggle_purebred_select_encryption</string>
 			<key>DefaultValue</key>
@@ -76,7 +76,7 @@
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
-			<string>All authentication keys (purebred.select.authentication)</string>
+			<string>All authentication keys (purebred2025.select.authentication)</string>
 			<key>Key</key>
 			<string>toggle_purebred_select_authentication</string>
 			<key>DefaultValue</key>
@@ -86,27 +86,27 @@
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
-			<string>All device keys (purebred.select.device)</string>
+			<string>All device keys (purebred2025.select.device)</string>
 			<key>Key</key>
 			<string>toggle_purebred_select_device</string>
 			<key>DefaultValue</key>
 			<true/>
 		</dict>
-        <dict>
-            <key>Type</key>
-            <string>PSToggleSwitchSpecifier</string>
-            <key>Title</key>
-            <string>All device keys (purebred.zip.all)</string>
-            <key>Key</key>
-            <string>toggle_purebred_zip_all</string>
-            <key>DefaultValue</key>
-            <false/>
-        </dict>
 		<dict>
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
-			<string>All user keys (purebred.zip.all.user)</string>
+			<string>All device keys (purebred2025.zip.all)</string>
+			<key>Key</key>
+			<string>toggle_purebred_zip_all</string>
+			<key>DefaultValue</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+			<key>Title</key>
+			<string>All user keys (purebred2025.zip.all.user)</string>
 			<key>Key</key>
 			<string>toggle_purebred_zip_all_user</string>
 			<key>DefaultValue</key>
@@ -116,7 +116,7 @@
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
-			<string>All user keys (purebred.zip.all-user)</string>
+			<string>All user keys (purebred2025.zip.all-user)</string>
 			<key>Key</key>
 			<string>toggle_purebred_zip_all-user</string>
 			<key>DefaultValue</key>
@@ -126,7 +126,7 @@
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
-			<string>Signature keys (purebred.zip.signature)</string>
+			<string>Signature keys (purebred2025.zip.signature)</string>
 			<key>Key</key>
 			<string>toggle_purebred_zip_signature</string>
 			<key>DefaultValue</key>
@@ -136,7 +136,7 @@
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
-			<string>All encryption keys (purebred.zip.encryption)</string>
+			<string>All encryption keys (purebred2025.zip.encryption)</string>
 			<key>Key</key>
 			<string>toggle_purebred_zip_encryption</string>
 			<key>DefaultValue</key>
@@ -146,7 +146,7 @@
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
-			<string>All authentication keys (purebred.zip.authentication)</string>
+			<string>All authentication keys (purebred2025.zip.authentication)</string>
 			<key>Key</key>
 			<string>toggle_purebred_zip_authentication</string>
 			<key>DefaultValue</key>
@@ -156,52 +156,52 @@
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
-			<string>All device keys (purebred.zip.device)</string>
+			<string>All device keys (purebred2025.zip.device)</string>
 			<key>Key</key>
 			<string>toggle_purebred_zip_device</string>
 			<key>DefaultValue</key>
 			<false/>
 		</dict>
-        <dict>
-            <key>Type</key>
-            <string>PSToggleSwitchSpecifier</string>
-            <key>Title</key>
-            <string>Do not filter on notBefore for zip files (purebred.zip.no_filter)</string>
-            <key>Key</key>
-            <string>toggle_purebred_zip_no_filter</string>
-            <key>DefaultValue</key>
-            <false/>
-        </dict>
-        <dict>
-            <key>Type</key>
-            <string>PSToggleSwitchSpecifier</string>
-            <key>Title</key>
-            <string>Do not filter on notBefore (purebred.select.no_filter)</string>
-            <key>Key</key>
-            <string>toggle_purebred_select_no_filter</string>
-            <key>DefaultValue</key>
-            <false/>
-        </dict>
-        <dict>
-            <key>Type</key>
-            <string>PSToggleSwitchSpecifier</string>
-            <key>Title</key>
-            <string>Do not filter on notBefore for zip files (purebred.zip.no-filter)</string>
-            <key>Key</key>
-            <string>toggle_purebred_zip_no-filter</string>
-            <key>DefaultValue</key>
-            <false/>
-        </dict>
-        <dict>
-            <key>Type</key>
-            <string>PSToggleSwitchSpecifier</string>
-            <key>Title</key>
-            <string>Do not filter on notBefore (purebred.select.no-filter)</string>
-            <key>Key</key>
-            <string>toggle_purebred_select_no-filter</string>
-            <key>DefaultValue</key>
-            <false/>
-        </dict>
+		<dict>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+			<key>Title</key>
+			<string>Do not filter on notBefore for zip files (purebred2025.zip.no_filter)</string>
+			<key>Key</key>
+			<string>toggle_purebred_zip_no_filter</string>
+			<key>DefaultValue</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+			<key>Title</key>
+			<string>Do not filter on notBefore (purebred2025.select.no_filter)</string>
+			<key>Key</key>
+			<string>toggle_purebred_select_no_filter</string>
+			<key>DefaultValue</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+			<key>Title</key>
+			<string>Do not filter on notBefore for zip files (purebred2025.zip.no-filter)</string>
+			<key>Key</key>
+			<string>toggle_purebred_zip_no-filter</string>
+			<key>DefaultValue</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+			<key>Title</key>
+			<string>Do not filter on notBefore (purebred2025.select.no-filter)</string>
+			<key>Key</key>
+			<string>toggle_purebred_select_no-filter</string>
+			<key>DefaultValue</key>
+			<false/>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/KeyShareConsumer/ViewController.m
+++ b/KeyShareConsumer/ViewController.m
@@ -6,10 +6,17 @@
 #import <UIKit/UIKit.h>
 #import "KeyDetailViewController.h"
 #import <CommonCrypto/CommonDigest.h>
+#import "UniformTypeIdentifiers/UTType.h"
 
 #import "ZipFile.h"
 #import "FileInZipInfo.h"
 #import "ZipReadStream.h"
+
+@protocol KeySharingPassword
+
+-(void)fetchPassword:(void (^_Nullable)(NSString* _Nullable password, NSError* _Nullable error))completionHandler;
+
+@end
 
 @interface ViewController ()<UIDocumentPickerDelegate>
 @end
@@ -57,53 +64,66 @@
     NSMutableArray* utis = [[NSMutableArray alloc]init];
     
     if([standardDefaults boolForKey:@"toggle_com_rsa_pkcs12"])
-        [utis addObject:@"com.rsa.pkcs-12"];
-    if([standardDefaults boolForKey:@"toggle_purebred_select_all"])
-        [utis addObject:@"purebred.select.all"];
-    if([standardDefaults boolForKey:@"toggle_purebred_select_all_user"])
-        [utis addObject:@"purebred.select.all_user"];
-    if([standardDefaults boolForKey:@"toggle_purebred_select_all-user"])
-        [utis addObject:@"purebred.select.all-user"];
-    if([standardDefaults boolForKey:@"toggle_purebred_select_signature"])
-        [utis addObject:@"purebred.select.signature"];
-    if([standardDefaults boolForKey:@"toggle_purebred_select_encryption"])
-        [utis addObject:@"purebred.select.encryption"];
-    if([standardDefaults boolForKey:@"toggle_purebred_select_authentication"])
-        [utis addObject:@"purebred.select.authentication"];
-    if([standardDefaults boolForKey:@"toggle_purebred_select_device"])
-        [utis addObject:@"purebred.select.device"];
-    if([standardDefaults boolForKey:@"toggle_purebred_select_no_filter"])
-        [utis addObject:@"purebred.select.no_filter"];
-    if([standardDefaults boolForKey:@"toggle_purebred_select_no-filter"])
-        [utis addObject:@"purebred.select.no-filter"];
-    if([standardDefaults boolForKey:@"toggle_purebred_select_no-filter"])
-        [utis addObject:@"purebred.select.no-filter"];
-    if([standardDefaults boolForKey:@"toggle_purebred_select_no-filter"])
-        [utis addObject:@"purebred.select.no-filter"];
+        [utis addObject:@"purebred2025.rsa.pkcs-12"];
+    if([standardDefaults boolForKey:@"toggle_purebred_select_all"]) {
+        [utis addObject:@"purebred2025.select.all"];
+        [utis addObject:@"purebred2025.select.all-p12"];
+    }
+    if([standardDefaults boolForKey:@"toggle_purebred_select_all-user"]) {
+        [utis addObject:@"purebred2025.select.all-user"];
+        [utis addObject:@"purebred2025.select.all-user-p12"];
+    }
+    if([standardDefaults boolForKey:@"toggle_purebred_select_signature"]) {
+        [utis addObject:@"purebred2025.select.signature"];
+        [utis addObject:@"purebred2025.select.signature-p12"];
+    }
+    if([standardDefaults boolForKey:@"toggle_purebred_select_encryption"]) {
+        [utis addObject:@"purebred2025.select.encryption"];
+        [utis addObject:@"purebred2025.select.encryption-p12"];
+    }
+    if([standardDefaults boolForKey:@"toggle_purebred_select_authentication"]) {
+        [utis addObject:@"purebred2025.select.authentication"];
+        [utis addObject:@"purebred2025.select.authentication-p12"];
+    }
+    if([standardDefaults boolForKey:@"toggle_purebred_select_device"]) {
+        [utis addObject:@"purebred2025.select.device"];
+        [utis addObject:@"purebred2025.select.device-p12"];
+    }
+    if([standardDefaults boolForKey:@"toggle_purebred_select_no-filter"]) {
+        [utis addObject:@"purebred2025.select.no-filter"];
+        [utis addObject:@"purebred2025.select.no-filter-p12"];
+    }
     if([standardDefaults boolForKey:@"toggle_purebred_zip_all"])
-        [utis addObject:@"purebred.zip.all"];
-    if([standardDefaults boolForKey:@"toggle_purebred_zip_all_user"])
-        [utis addObject:@"purebred.zip.all_user"];
+        [utis addObject:@"purebred2025.zip.all"];
     if([standardDefaults boolForKey:@"toggle_purebred_zip_all-user"])
-        [utis addObject:@"purebred.zip.all-user"];
+        [utis addObject:@"purebred2025.zip.all-user"];
     if([standardDefaults boolForKey:@"toggle_purebred_zip_signature"])
-        [utis addObject:@"purebred.zip.signature"];
+        [utis addObject:@"purebred2025.zip.signature"];
     if([standardDefaults boolForKey:@"toggle_purebred_zip_encryption"])
-        [utis addObject:@"purebred.zip.encryption"];
+        [utis addObject:@"purebred2025.zip.encryption"];
     if([standardDefaults boolForKey:@"toggle_purebred_zip_authentication"])
-        [utis addObject:@"purebred.zip.authentication"];
+        [utis addObject:@"purebred2025.zip.authentication"];
     if([standardDefaults boolForKey:@"toggle_purebred_zip_device"])
-        [utis addObject:@"purebred.zip.device"];
-    if([standardDefaults boolForKey:@"toggle_purebred_zip_no_filter"])
-        [utis addObject:@"purebred.zip.no_filter"];
+        [utis addObject:@"purebred2025.zip.device"];
     if([standardDefaults boolForKey:@"toggle_purebred_zip_no-filter"])
-        [utis addObject:@"purebred.zip.no-filter"];
+        [utis addObject:@"purebred2025.zip.no-filter"];
 
     if(0 == [utis count])
-        [utis addObject:@"com.rsa.pkcs-12"];
+        [utis addObject:@"purebred2025.rsa.pkcs-12"];
     
+    NSMutableArray* uniformTypeIdentifiers = [[NSMutableArray alloc]init];
+    for (NSString* curUti in utis)
+    {
+        UTType* uti = [UTType typeWithIdentifier:curUti];
+        if (uti != nil) {
+            [uniformTypeIdentifiers addObject:uti];
+        } else {
+            NSLog(@"Unable to convert to UTType %@", curUti);
+        }
+    }
     //Display the UIDocumentPickerViewController to enable the user to select a key to import. Purebred Registration only works with UIDocumentPickerModeOpen mode.
-    UIDocumentPickerViewController *documentPicker = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:utis inMode:UIDocumentPickerModeOpen];
+    // UIDocumentPickerViewController *documentPicker = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:utis inMode:UIDocumentPickerModeOpen];
+    UIDocumentPickerViewController *documentPicker = [[UIDocumentPickerViewController alloc] initForOpeningContentTypes: uniformTypeIdentifiers];
     documentPicker.delegate = self;
     documentPicker.modalPresentationStyle = UIModalPresentationFormSheet;
     [self presentViewController:documentPicker animated:YES completion:nil];
@@ -126,58 +146,88 @@
 
 - (void)documentPicker:(UIDocumentPickerViewController *)controller didPickDocumentsAtURLs:(NSArray<NSURL *>*)urls {
     NSURL* url = urls[0];
-    if(controller.documentPickerMode == UIDocumentPickerModeOpen)
-    {
-        BOOL startAccessingWorked = [url startAccessingSecurityScopedResource];
-        NSURL *ubiquityURL = [[NSFileManager defaultManager] URLForUbiquityContainerIdentifier:nil];
-        NSLog(@"ubiquityURL %@",ubiquityURL);
-        NSLog(@"start %d",startAccessingWorked);
-        
-        NSFileCoordinator *fileCoordinator = [[NSFileCoordinator alloc] init];
-        NSError *error;
-        [fileCoordinator coordinateReadingItemAtURL:url options:0 error:&error byAccessor:^(NSURL *newURL) {
-            NSData *data = [NSData dataWithContentsOfURL:newURL];
-            
-            NSLog(@"error %@",error);
-            NSLog(@"data %@",data);
-            if(nil == data)
-                return;
+    BOOL startAccessingWorked = [url startAccessingSecurityScopedResource];
 
-            // Read the password from the pasteboard
-            UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
-            NSString* pw = [pasteboard string];
+    [[NSFileManager defaultManager] getFileProviderServicesForItemAtURL:url completionHandler:^(NSDictionary<NSFileProviderServiceName,NSFileProviderService *> * _Nullable services, NSError * _Nullable error) {
+        if (nil != services) {
             
-            if(nil != pw && 0 != [pw length])
-            {
-                passwordFromUser = pw;
+            NSArray* keys = [services allKeys];
+
+            for(NSString* key in keys) {
+                NSFileProviderService* obj = [services objectForKey:key];
+                
+                [obj getFileProviderConnectionWithCompletionHandler:^(NSXPCConnection * _Nullable connection, NSError * _Nullable error) {
+                    if(nil != error) {
+                        NSLog(@"getFileProviderConnectionWithCompletionHandler received an error: %@", error);
+                        return;
+                    }
+                    if (nil == connection) {
+                        NSLog(@"getFileProviderConnectionWithCompletionHandler did not receive a connection object");
+                        return;
+                    }
+
+                    connection.remoteObjectInterface = [NSXPCInterface interfaceWithProtocol: @protocol(KeySharingPassword)];
+                    [connection resume];
+                    //[connection remoteObjectProxy];
+                    
+                    id<KeySharingPassword> helperProxy = [connection remoteObjectProxyWithErrorHandler:^(NSError* error) {
+                            NSLog(@"remoteObjectProxyWithErrorHandler: Connection error: %@", error);
+                        }];
+
+                    if (nil == helperProxy) {
+                        NSLog(@"remoteObjectProxyWithErrorHandler did not return a proxy");
+                        return;
+                    }
+                    
+                    [helperProxy fetchPassword:^(NSString * _Nullable password, NSError * _Nullable error) {
+                        NSURL *ubiquityURL = [[NSFileManager defaultManager] URLForUbiquityContainerIdentifier:nil];
+                        NSLog(@"ubiquityURL %@",ubiquityURL);
+                        NSLog(@"start %d",startAccessingWorked);
+                        
+                        NSFileCoordinator *fileCoordinator = [[NSFileCoordinator alloc] init];
+                        [fileCoordinator coordinateReadingItemAtURL:url options:0 error:&error byAccessor:^(NSURL *newURL) {
+                            NSData *data = [NSData dataWithContentsOfURL:newURL];
+                            
+                            NSLog(@"error %@",error);
+                            NSLog(@"data %@",data);
+                            if(nil == data)
+                                return;
+                            
+                            if(nil != password && 0 != [password length])
+                            {
+                                passwordFromUser = password;
+                            }
+                            
+                            pkcs12Data = data;
+                        }];
+                        if(nil == passwordFromUser || 0 == [passwordFromUser length])
+                        {
+                            dispatch_async(dispatch_get_main_queue(), ^{
+                                UIAlertView * alert = [[UIAlertView alloc] initWithTitle:@"Enter Password" message:@"Please enter the password for the selected PKCS #12 file" delegate:self cancelButtonTitle:@"Cancel" otherButtonTitles: @"OK", nil];
+                                alert.alertViewStyle = UIAlertViewStyleSecureTextInput;
+                                [alert show];
+                            });
+                        }
+                        else{
+                            // MOD: added sanity check to avoid crasher on file read miss
+                            if ([pkcs12Data length] > 0) {
+                                dispatch_async(dispatch_get_main_queue(), ^{
+                                    [self importP12:pkcs12Data password:passwordFromUser];
+                                });
+                            }
+                            else {
+                                NSLog(@"Read zero bytes from %@", url);
+                            }
+                        }
+                        [url stopAccessingSecurityScopedResource];
+                    }];
+                }];
             }
-
-            pkcs12Data = data;
-       }];
-        [url stopAccessingSecurityScopedResource];
-        
-        if(nil == passwordFromUser || 0 == [passwordFromUser length])
-        {
-            UIAlertView * alert = [[UIAlertView alloc] initWithTitle:@"Enter Password" message:@"Please enter the password for the selected PKCS #12 file" delegate:self cancelButtonTitle:@"Cancel" otherButtonTitles: @"OK", nil];
-            alert.alertViewStyle = UIAlertViewStyleSecureTextInput;
-            [alert show];
         }
-        else{
-            /*
-            NSString* p12File = @"tmp.p12";
-            
-            NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-            NSString *documentsDirectory = [paths objectAtIndex:0];
-            NSString *p12Path = [documentsDirectory stringByAppendingPathComponent:p12File];
-            
-            NSLog(@"Password: %@", passwordFromUser);
-            //Write the private key and certificate to a pair of files
-            [pkcs12Data writeToFile:p12Path atomically:YES];
-            */
-            
-            [self importP12:pkcs12Data password:passwordFromUser];
+        else {
+            NSLog(@"Services was nil. Error: %@", error);
         }
-    }
+    }] ;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Changes related to key sharing 2025
- Update Settings.bundle to reflect UTI changes
- Update openImportDocumentPicker to reflect UTI changes, including pairing new "-p12" UTIs with "select.*" UTIs
- Present array of UTType to UIDocumentPickerViewController instead of array of NSString using a non-deprecated initialization method
- Add definition of KeySharingPassword protocol
- Replace use of system pasteboard to retrieve PKCS #12 password with use of service provided by the file provider

Changes unrelated to key sharing 2025:
- Comment out subject and issuer name from attributes list (since no name parser is linked in)
- Change development team